### PR TITLE
Resolve null-pointer exception for resources without Tags

### DIFF
--- a/cloudconnect.go
+++ b/cloudconnect.go
@@ -138,6 +138,8 @@ func getChangeAction(m Manager, a *Attachment, allocation *Allocation, currentRe
 		if allocation != nil {
 			return ApproveAttachment, "account is allocated", nil
 		}
+
+		// This rejects (deletes) all pending allowed tgw-attachments, that have not been completed within 3 days, to attempt a retry the tgw-attachments need to be tried.
 		if a.Created.Before(time.Now().AddDate(0, 0, -3)) {
 			return RejectAttachment, "pending without allocation for >3 days", nil
 		}
@@ -165,10 +167,12 @@ func getChangeAction(m Manager, a *Attachment, allocation *Allocation, currentRe
 			}
 		}
 	}
-	nameTag, _ := a.Tags["Name"]
-	if nameTag != allocation.Name {
-		return TagAttachment, "name tag does not match allocation", nil
+	if nameTag, ok := a.Tags["Name"]; ok {
+		if nameTag != allocation.Name {
+			return TagAttachment, "name tag does not match allocation", nil
+		}
 	}
+
 	return NoOp, "", nil
 }
 

--- a/cloudconnect_test.go
+++ b/cloudconnect_test.go
@@ -135,6 +135,31 @@ func TestPlan(t *testing.T) {
 			expectedSearchRouteCalls: 1,
 			propagatedRoute:          "10.1.2.0/25",
 			expectedAction:           cloudconnect.NoOp,
+		}, {
+			description: "no-op if propagation is rejected and no tag",
+			attachment: &cloudconnect.Attachment{
+				ID:    cloudconnect.AttachmentID("ID"),
+				Owner: targetOwner,
+				Type:  "vpc",
+				State: "rejected",
+				Tags:  nil,
+			},
+			expectedSearchRouteCalls: 0,
+			propagatedRoute:          "10.1.2.0/25",
+			expectedAction:           cloudconnect.NoOp,
+		},
+		{
+			description: "no-op if propagation is deleted and no tag",
+			attachment: &cloudconnect.Attachment{
+				ID:    cloudconnect.AttachmentID("ID"),
+				Owner: targetOwner,
+				Type:  "vpc",
+				State: "deleted",
+				Tags:  nil,
+			},
+			expectedSearchRouteCalls: 0,
+			propagatedRoute:          "10.1.2.0/25",
+			expectedAction:           cloudconnect.NoOp,
 		},
 	}
 


### PR DESCRIPTION
This hopefully resolves #1 by ensuring that attempts to fetch Tags take into account the fact some resources might not include them, for example when manually deleting a attachment before the lambda has detected it and tagged it with information from the `allocations.yml` file.

It adds the following changes, to resolve the issue

```
if nameTag, ok := a.Tags["Name"]; ok {
  if nameTag != allocation.Name {
	  return TagAttachment, "name tag does not match allocation", nil
  }
}
```

It also adds the following test cases

* Rejected without Tags
* Deleted without Tags